### PR TITLE
Add support for GeoTools 26.2 for the PGDB driver

### DIFF
--- a/jdbc-pgdb/pom.xml
+++ b/jdbc-pgdb/pom.xml
@@ -16,7 +16,7 @@
   <artifactId>gt-jdbc-pgdb</artifactId>
   <packaging>jar</packaging>
   <name>ESRI Personal Geodatabase DataStore</name>
-  <version>21-SNAPSHOT</version>
+  <version>26.2</version>
   <description>DataStore for ESRI Personal Geodatabase.</description>
   
   <licenses>
@@ -47,7 +47,7 @@
     <repository>
       <id>osgeo</id>
       <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
+      <url>https://download.osgeo.org/webdav/geotools/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -55,7 +55,7 @@
     <repository>
       <id>geosolutions</id>
       <name>GeoSolutions Repository</name>
-      <url>http://maven.geo-solutions.it</url>
+      <url>https://maven.geo-solutions.it</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -63,7 +63,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Restlet Maven Repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.org</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -98,11 +98,6 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
-      <artifactId>gt-data</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools</groupId>
       <artifactId>gt-jdbc</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -115,6 +110,11 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ucanaccess</groupId>
+      <artifactId>ucanaccess</artifactId>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/GDBSchema.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/GDBSchema.java
@@ -20,11 +20,11 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
 
 /**
  * GDB Schema for ESRI Personal Geodatabase

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/JdbcUtilities.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/JdbcUtilities.java
@@ -29,14 +29,14 @@ import java.util.logging.Logger;
 
 import org.geotools.util.logging.Logging;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 /**
  * Jdbc Utilities for Access

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBDataStoreFactory.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBDataStoreFactory.java
@@ -18,20 +18,16 @@ package org.geotools.data.pgdb;
 
 import java.awt.RenderingHints.Key;
 import java.io.IOException;
-import java.io.Serializable;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Logger;
 
-import org.geotools.data.AbstractDataStoreFactory;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFactorySpi;
-import org.geotools.data.DataUtilities;
 import org.geotools.data.Parameter;
 import org.geotools.util.KVP;
 import org.geotools.util.SimpleInternationalString;
-import org.geotools.util.logging.Logging;
+import org.geotools.util.URLs;
 
 /**
  * ESRI Personal Geodatabase DataStoreFactory
@@ -41,13 +37,11 @@ import org.geotools.util.logging.Logging;
  * @see
  * 
  */
-public class PGDBDataStoreFactory extends AbstractDataStoreFactory implements DataStoreFactorySpi {
-    protected static final Logger LOGGER = Logging.getLogger(PGDBDataStoreFactory.class);
-
+public class PGDBDataStoreFactory implements DataStoreFactorySpi {
     static final String FILE_TYPE = "mdb";
 
     public static final Param PARAM_FILE = new Param("url", URL.class,
-            "url to a ESRI Personal Geodatabase(.mdb) file", true, null, new KVP(Param.EXT,
+            "URL to a ESRI Personal Geodatabase(.mdb) file", true, null, new KVP(Param.EXT,
                     FILE_TYPE));
 
     /** parameter for database user */
@@ -55,7 +49,7 @@ public class PGDBDataStoreFactory extends AbstractDataStoreFactory implements Da
 
     /** parameter for database password */
     public static final Param PARAM_PASSWD = new Param("passwd", String.class,
-            new SimpleInternationalString("password used to login"), false, null,
+            new SimpleInternationalString("Password used to login"), false, null,
             Collections.singletonMap(Parameter.IS_PASSWORD, Boolean.TRUE));
 
     public String getDisplayName() {
@@ -93,18 +87,19 @@ public class PGDBDataStoreFactory extends AbstractDataStoreFactory implements Da
         return result;
     }
 
-    public DataStore createDataStore(Map<String, Serializable> params) throws IOException {
+    @Override
+    public DataStore createDataStore(Map<String, ?> params) throws IOException {
         URL url = (URL) PARAM_FILE.lookUp(params);
         String user = (String) PARAM_USER.lookUp(params);
         String password = (String) PARAM_PASSWD.lookUp(params);
 
         // it is immutable and cannot be modified
-        final DataStore dataStore = new PGDBDataStore(DataUtilities.urlToFile(url), user, password);
+        final DataStore dataStore = new PGDBDataStore(URLs.urlToFile(url), user, password);
         return dataStore;
     }
 
-    public DataStore createNewDataStore(Map<String, Serializable> params) throws IOException {
+    @Override
+    public DataStore createNewDataStore(Map<String, ?> map) {
         return null;
     }
-
 }

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBDecoder.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBDecoder.java
@@ -25,13 +25,13 @@ import org.geotools.data.shapefile.shp.MultiLineHandler;
 import org.geotools.data.shapefile.shp.MultiPointHandler;
 import org.geotools.data.shapefile.shp.PolygonHandler;
 import org.geotools.data.shapefile.shp.ShapeType;
-import org.geotools.factory.GeoTools;
 import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
  * Geometry Decoder for ESRI Personal Geodatabase

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBFeatureReader.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBFeatureReader.java
@@ -26,18 +26,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.geotools.data.FeatureReader;
-import org.geotools.factory.GeoTools;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.JTSFactoryFinder;
 import org.geotools.util.Converters;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
  * ESRI Personal Geodatabase FeatureReader
@@ -80,8 +80,8 @@ public class PGDBFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
 
     private void queryLayer() {
         try {
-            String sql = "SELECT * FROM \"";
-            sql += JdbcUtilities.toAccess(schema.getTypeName()) + "\"";
+            String sql = "SELECT * FROM ";
+            sql += JdbcUtilities.toAccess(schema.getTypeName());
             stmt = cx.createStatement();
             rs = stmt.executeQuery(sql);
         } catch (SQLException e) {

--- a/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBFeatureSource.java
+++ b/jdbc-pgdb/src/main/java/org/geotools/data/pgdb/PGDBFeatureSource.java
@@ -16,13 +16,20 @@
  */
 package org.geotools.data.pgdb;
 
-import java.util.Set;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.geotools.data.AbstractFeatureSource;
-import org.geotools.data.DataStore;
-import org.geotools.data.FeatureListener;
+import org.geotools.data.FeatureReader;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
+import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 /**
@@ -34,33 +41,68 @@ import org.opengis.feature.simple.SimpleFeatureType;
  * 
  */
 @SuppressWarnings("unchecked")
-public class PGDBFeatureSource extends AbstractFeatureSource {
+public class PGDBFeatureSource extends ContentFeatureSource {
     protected static final Logger LOGGER = Logging.getLogger(PGDBFeatureSource.class);
 
     private final PGDBDataStore dataStore;
 
-    private final SimpleFeatureType featureType;
-
     @SuppressWarnings("rawtypes")
-    public PGDBFeatureSource(PGDBDataStore dataStore, Set hints, SimpleFeatureType featureType) {
-        super(hints);
+    public PGDBFeatureSource(PGDBDataStore dataStore, ContentEntry contentEntry) throws IOException {
+        super(contentEntry, new Query(Query.ALL));
+        this.query.setTypeName(contentEntry.getTypeName());
         this.dataStore = dataStore;
-        this.featureType = featureType;
     }
 
-    public DataStore getDataStore() {
-        return dataStore;
+    @Override
+    protected SimpleFeatureType buildFeatureType() throws IOException {
+        String typeName = this.entry.getTypeName();
+        GDBSchema gdbSchema = dataStore.sr.getSchemas().get(typeName);
+        if (gdbSchema == null) {
+            throw new IOException(typeName + " does not exist!");
+        }
+
+        if (gdbSchema.getSchema() == null) {
+            dataStore.sr.buildFeatureType(gdbSchema);
+        }
+        return gdbSchema.getSchema();
     }
 
-    public void addFeatureListener(FeatureListener listener) {
-        dataStore.listenerManager.addFeatureListener(this, listener);
+    @Override
+    protected ReferencedEnvelope getBoundsInternal(Query query) throws IOException {
+        GDBSchema gdbSchema = dataStore.sr.getSchemas().get(query.getTypeName());
+        if (gdbSchema == null) {
+            throw new IOException(query.getTypeName() + " does not exist!");
+        }
+        return gdbSchema.getExtent();
     }
 
-    public void removeFeatureListener(FeatureListener listener) {
-        dataStore.listenerManager.removeFeatureListener(this, listener);
+    @Override
+    protected int getCountInternal(Query query) throws IOException {
+        GDBSchema gdbSchema = dataStore.sr.getSchemas().get(query.getTypeName());
+        if (gdbSchema == null) {
+            throw new IOException(query.getTypeName() + " does not exist!");
+        }
+
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            String sql = "SELECT COUNT(*) FROM \"" + JdbcUtilities.toAccess(query.getTypeName())
+                    + "\"";
+            stmt = dataStore.getConnection().createStatement();
+            rs = stmt.executeQuery(sql);
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.FINER, e.getMessage(), e);
+        } finally {
+            JdbcUtilities.closeSafe(rs, stmt);
+        }
+        return -1;
     }
 
-    public SimpleFeatureType getSchema() {
-        return featureType;
+    @Override
+    protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query) throws IOException {
+        return dataStore.getFeatureReader(query.getTypeName());
     }
 }


### PR DESCRIPTION
Hi and thank you for this nice library. As we are using a newer version of GeoTools, we are working to add 26.2 support for the ESRI PGDB driver. The main changes are also specified in the commit message:

- Update GeoTools version to 26.2
- Upgrade JTS package name
- Upgrade GeoTools package import
- Migrate to the more recent ContentDataStore API
- Use UCanAccess JDBC driver instead of the JDBC-ODBC bridge driver

Please review 🙏 